### PR TITLE
Removed VS Attribution Window

### DIFF
--- a/Editor/WelcomeWindow.cs
+++ b/Editor/WelcomeWindow.cs
@@ -31,18 +31,11 @@ namespace DolbyIO.Comms.Unity.Editor
             var text = new StringBuilder("Packages:\n");
             foreach (var package in packages)
             {
-                if (package.name == "dolbyio.comms.unity")
+                if (package.name == "dolbyio.comms.unity" && package.source == PackageSource.Registry)
                 {
                     WelcomeWindow.Initialize();
                 }
             }
-
-        }
-
-        [MenuItem("Window/Dolby.io Comms Welcome")]
-        public static void Initialize()
-        {
-            GetWindow<WelcomeWindow>("Welcome!");
         }
 
         void OnEnable()


### PR DESCRIPTION
VS Attribution Windows will now only pop up when installed from the store.