### PR TITLE
Registering VideoControllers bug

### DIFF
--- a/Runtime/Components/video/VideoController.cs
+++ b/Runtime/Components/video/VideoController.cs
@@ -41,6 +41,8 @@ namespace DolbyIO.Comms.Unity
             if (Conference)
             {
                 Conference.RegisterVideoController(this);
+            }else{
+                Debug.LogWarning("No conference found on VideoController");
             }
         }
 
@@ -51,6 +53,8 @@ namespace DolbyIO.Comms.Unity
             if (renderer)
             {
                 VideoRenderer = new VideoRenderer(renderer.material);
+            }else{
+                Debug.LogWarning("No renderer found on VideoController");
             }
         }
 
@@ -82,7 +86,11 @@ namespace DolbyIO.Comms.Unity
                         Debug.LogWarning(t.Exception.Message);
                     },
                     TaskContinuationOptions.OnlyOnFaulted);
+                }else{
+                    // Debug.LogWarning("No participant id found on video track");
                 }
+            }else{
+                // Debug.LogWarning("Video track already set");
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dolbyio.comms.unity",
-    "version": "1.2.0",
+    "version": "1.2.2",
     "unity": "2021.1",
     "displayName": "DolbyIO Communications",
     "description": "The DolbyIO Virtual World Plugin for Unity",


### PR DESCRIPTION
The ConferenceController RegisterVideoControllers would break out of the iteration of VideoControllers after it found the local player. This prevented any other remote players from having their VideoTrack assigned.